### PR TITLE
fix getRequestPostData

### DIFF
--- a/lib/models/request.js
+++ b/lib/models/request.js
@@ -38,7 +38,7 @@ export default class Request extends Actor {
      */
     async getRequestPostData () {
         const { postData } = await this.request('getRequestPostData')
-        if (postData.text.type && postData.text.type === 'longString') {
+        if (postData.text && postData.text.type && postData.text.type === 'longString') {
             const longPost = new LongString(this.client, postData.text.actor)
             return longPost.substring(0, postData.text.length)
         }


### PR DESCRIPTION
**Problem:** getRequestPostData throws error when `postData.text` is undefined.
**Solution:** Check if `postData.text` is available before going forward.