### PR TITLE
getImageDataFromURL to always return complete image data

### DIFF
--- a/lib/domains/inspector.js
+++ b/lib/domains/inspector.js
@@ -75,7 +75,7 @@ export default class Inspector extends Actor {
      */
     async getImageDataFromURL (url, maxDim) {
         const { data, size } = await this.request('getImageDataFromURL', { url, maxDim })
-        if(data.type && data.type === 'longString') {
+        if (data.type && data.type === 'longString') {
             const imageBlob = new LongString(this.client, data.actor)
             const imageData = await imageBlob.substring(0, data.length)
             return { data: imageData, size }

--- a/lib/domains/inspector.js
+++ b/lib/domains/inspector.js
@@ -1,6 +1,7 @@
 import Actor from '../actor'
 import Highlighter from '../models/highlighter'
 import Pagestyle from '../models/pagestyle'
+import LongString from '../models/longString'
 
 /**
  * Server side of the inspector actor, which is used to create
@@ -72,8 +73,14 @@ export default class Inspector extends Actor {
      * @param  {Number} maxDim     resizing parameter
      * @return {Promise.<Object>}  image data
      */
-    getImageDataFromURL (url, maxDim) {
-        return this.request('getImageDataFromURL', { url, maxDim })
+    async getImageDataFromURL (url, maxDim) {
+        const { data, size } = await this.request('getImageDataFromURL', { url, maxDim })
+        if(data.type && data.type === 'longString') {
+            const imageBlob = new LongString(this.client, data.actor)
+            const imageData = await imageBlob.substring(0, data.length)
+            return { data: imageData, size }
+        }
+        return { data, size }
     }
 
     /**


### PR DESCRIPTION
Sometimes `getImageDataFromURL` would return partial data, particularly when inspecting large images.
Now it will handle this special case, and query for the complete data.