### PR TITLE
Fixed missing /build directory in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           name: compiled-package
           path: build/
+          if-no-files-found: error
 
   release:
     needs: test
@@ -55,6 +56,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: compiled-package
+          path: build/
       - name: Release
         run: npm run release:ci -- ${{github.event.inputs.releaseType}}
         env:


### PR DESCRIPTION
This PR fixes missing `/build` directory in release workflow. Package has been released without build files, so it was not possible to import it to the project. It seems that `actions/download-artifact@v2` requires explicit `path` option in order to recreate proper files structure (see [docs](https://github.com/actions/download-artifact#compatibility-between-v1-and-v2)).